### PR TITLE
Fix gradient defaults in Hero block

### DIFF
--- a/admin/templates/tabs/hero.php
+++ b/admin/templates/tabs/hero.php
@@ -155,30 +155,14 @@ $title_color      = Options::getFieldWithDefaults(Options::TITLE_COLOR);
                 type="color"
                 id="<?= Options::COLOR_FOR_GRADIENT ?>"
                 name="<?= Options::COLOR_FOR_GRADIENT ?>"
-                value="<?= esc_attr(get_option(Options::COLOR_FOR_GRADIENT, '#ededed')); ?>"
+                value="<?= esc_attr(get_option(Options::COLOR_FOR_GRADIENT, Options::DEFAULTS[Options::COLOR_FOR_GRADIENT])); ?>"
                 style="vertical-align: middle;"
                 data-default="<?= esc_attr(expand_short_hex(Options::DEFAULTS[Options::COLOR_FOR_GRADIENT])) ?>"
             />
             <p class="description">
                 Цей колір буде використовуватися як другий колір для градієнту фону
-                <br>Буде використовуватися лише якщо увімкнено "Градієнт фону"
+                <br>Буде застосовуватися лише якщо в блоці увімкнено "Градієнт фону"
             </p>
-        </td>
-    </tr>
-    <tr>
-        <th scope="row">
-            <label for="<?= Options::IS_ENABLED_GRADIENT ?>">Градієнт фону:</label>
-        </th>
-        <td>
-            <input
-                type="checkbox"
-                id="<?= Options::IS_ENABLED_GRADIENT ?>"
-                name="<?= Options::IS_ENABLED_GRADIENT ?>"
-                value="1"
-                <?= get_option(Options::IS_ENABLED_GRADIENT) ? 'checked' : ''; ?>
-                data-default="<?= esc_attr(Options::DEFAULTS[Options::IS_ENABLED_GRADIENT]) ?>"
-            />
-            <label for="<?= Options::IS_ENABLED_GRADIENT ?>">Увімкнути градієнт</label>
         </td>
     </tr>
     <tr>

--- a/blocks/hero/fields.php
+++ b/blocks/hero/fields.php
@@ -85,7 +85,7 @@ function register_hero_acf_fields()
                 'ui' => 1,
                 'ui_on_text' => 'On',
                 'ui_off_text' => 'Off',
-                'default_value' => 0,
+                'default_value' => 1,
             ),
             array(
                 'key' => 'field_hero_cards',

--- a/blocks/hero/options.php
+++ b/blocks/hero/options.php
@@ -20,13 +20,15 @@ final class Options {
     const COLOR_FOR_GRADIENT  = 'blockify_hero_color_for_gradient';
 
     const DEFAULTS = [
-        self::SUBTITLE         => '',
-        self::HERO_IMAGE_ID    => '',
-        self::HERO_IMAGE_TOP   => -50,
-        self::HERO_IMAGE_RIGHT => -150,
-        self::TITLE_COLOR      => '#000',
-        self::SUBTITLE_COLOR   => '#000',
-        self::BACKGROUND_COLOR => '#ededed',
+        self::SUBTITLE          => '',
+        self::HERO_IMAGE_ID     => '',
+        self::HERO_IMAGE_TOP    => -50,
+        self::HERO_IMAGE_RIGHT  => -150,
+        self::TITLE_COLOR       => '#000',
+        self::SUBTITLE_COLOR    => '#000',
+        self::BACKGROUND_COLOR  => '#ededed',
+        self::IS_ENABLED_GRADIENT => 1,
+        self::COLOR_FOR_GRADIENT => '#ededed',
     ];
 
     const UPDATE_METHODS = [
@@ -40,9 +42,7 @@ final class Options {
         self::COLOR_FOR_GRADIENT => 'sanitize_hex_color',
     ];
 
-    const CHECKBOX_KEYS = [
-        self::IS_ENABLED_GRADIENT,
-    ];
+    const CHECKBOX_KEYS = [];
 
     const GLOBAL_KEYS = [
         self::SUBTITLE,
@@ -52,7 +52,6 @@ final class Options {
         self::TITLE_COLOR,
         self::SUBTITLE_COLOR,
         self::BACKGROUND_COLOR,
-        self::IS_ENABLED_GRADIENT,
         self::COLOR_FOR_GRADIENT,
     ];
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -118,13 +118,13 @@ if (!function_exists('blockify_get_field')) {
     {
         $local = get_field($option_name); // Get the value from the local ACF field first
 
-        if (!empty($local) || $local === '0') {
+        if ($local !== null && $local !== '') {
             return $local;
         }
 
         $global = get_option($option_name);
 
-        if (!empty($global) || $global === '0') {
+        if ($global !== null && $global !== '') {
             return $global;
         }
 


### PR DESCRIPTION
## Summary
- allow `blockify_get_field` to return `0` values
- set default Hero gradient color equal to background color
- enable Hero block gradient by default
- drop global gradient option in admin

## Testing
- `php -l includes/helpers.php`
- `php -l blocks/hero/options.php`
- `php -l blocks/hero/fields.php`
- `php -l admin/templates/tabs/hero.php`


------
https://chatgpt.com/codex/tasks/task_e_68431dcd5380832c9fee0fc1f113a577