### PR TITLE
Додано локальні налаштування позиції зображення в Hero

### DIFF
--- a/blocks/hero/fields.php
+++ b/blocks/hero/fields.php
@@ -40,6 +40,18 @@ function register_hero_acf_fields()
                 'instructions' => 'Image size: 650x774. Not required.',
             ),
             array(
+                'key' => create_acf_key(Options::HERO_IMAGE_TOP),
+                'name' => Options::HERO_IMAGE_TOP,
+                'label' => 'Hero image top',
+                'type' => 'number',
+            ),
+            array(
+                'key' => create_acf_key(Options::HERO_IMAGE_RIGHT),
+                'name' => Options::HERO_IMAGE_RIGHT,
+                'label' => 'Hero image right',
+                'type' => 'number',
+            ),
+            array(
                 'key' => create_acf_key(Options::TITLE_COLOR),
                 'name' => Options::TITLE_COLOR,
                 'label' => 'Title color',


### PR DESCRIPTION
## Опис
- додано два ACF поля для задавання відступів зверху та справа для картинки героя

## Тести
- `php -l blocks/hero/fields.php`

------
https://chatgpt.com/codex/tasks/task_e_684342283704832cb23db28b7fa4c6bb