### PR TITLE
Add global hero gradient option

### DIFF
--- a/admin/templates/tabs/hero.php
+++ b/admin/templates/tabs/hero.php
@@ -167,6 +167,21 @@ $title_color      = Options::getFieldWithDefaults(Options::TITLE_COLOR);
     </tr>
     <tr>
         <th scope="row">
+            <label for="<?= Options::IS_ENABLED_GRADIENT ?>">Увімкнути градієнт:</label>
+        </th>
+        <td>
+            <input
+                type="checkbox"
+                id="<?= Options::IS_ENABLED_GRADIENT ?>"
+                name="<?= Options::IS_ENABLED_GRADIENT ?>"
+                value="1"
+                <?= checked(get_option(Options::IS_ENABLED_GRADIENT, Options::DEFAULTS[Options::IS_ENABLED_GRADIENT]), 1, false); ?>
+                data-default="<?= esc_attr(Options::DEFAULTS[Options::IS_ENABLED_GRADIENT]) ?>"
+            />
+        </td>
+    </tr>
+    <tr>
+        <th scope="row">
             <label for="reset-hero-settings">Скинути на стандартні налаштування:</label>
         </th>
         <td>

--- a/blocks/hero/fields.php
+++ b/blocks/hero/fields.php
@@ -15,6 +15,16 @@ function register_hero_acf_fields()
         'title' => 'Hero Fields',
         'fields' => array(
             array(
+                'key' => create_acf_key(Options::USE_GLOBAL_OPTIONS),
+                'name' => Options::USE_GLOBAL_OPTIONS,
+                'label' => 'Use global options',
+                'type' => 'true_false',
+                'ui' => 1,
+                'ui_on_text' => 'On',
+                'ui_off_text' => 'Off',
+                'default_value' => 0,
+            ),
+            array(
                 'key' => create_acf_key(Options::TITLE),
                 'name' => Options::TITLE,
                 'label' => 'Title',

--- a/blocks/hero/options.php
+++ b/blocks/hero/options.php
@@ -18,6 +18,7 @@ final class Options {
     const BACKGROUND_COLOR    = 'hero_color'; // must be "blockify_hero_background_color" but for backward compatibility left as "hero_color"
     const IS_ENABLED_GRADIENT = 'blockify_hero_is_enabled_gradient';
     const COLOR_FOR_GRADIENT  = 'blockify_hero_color_for_gradient';
+    const USE_GLOBAL_OPTIONS  = 'blockify_hero_use_global_options';
 
     const DEFAULTS = [
         self::SUBTITLE            => '',
@@ -29,6 +30,7 @@ final class Options {
         self::BACKGROUND_COLOR    => '#ededed',
         self::IS_ENABLED_GRADIENT => 1,
         self::COLOR_FOR_GRADIENT  => '#ededed',
+        self::USE_GLOBAL_OPTIONS  => 0,
     ];
 
     const UPDATE_METHODS = [
@@ -42,7 +44,9 @@ final class Options {
         self::COLOR_FOR_GRADIENT => 'sanitize_hex_color',
     ];
 
-    const CHECKBOX_KEYS = [];
+    const CHECKBOX_KEYS = [
+        self::IS_ENABLED_GRADIENT,
+    ];
 
     const GLOBAL_KEYS = [
         self::SUBTITLE,
@@ -53,9 +57,16 @@ final class Options {
         self::SUBTITLE_COLOR,
         self::BACKGROUND_COLOR,
         self::COLOR_FOR_GRADIENT,
+        self::IS_ENABLED_GRADIENT,
     ];
 
     public static function getFieldWithDefaults($field_name) {
+        $use_global = get_field(self::USE_GLOBAL_OPTIONS);
+
+        if ($use_global) {
+            return blockify_get_field_global_first($field_name, self::DEFAULTS);
+        }
+
         return blockify_get_field($field_name, self::DEFAULTS);
     }
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -114,8 +114,8 @@ if (!function_exists('blockify_get_field')) {
      *
      * @return mixed
      */
-    function blockify_get_field(string $option_name, array $defaults)
-    {
+function blockify_get_field(string $option_name, array $defaults)
+{
         $local = get_field($option_name); // Get the value from the local ACF field first
 
         if (!empty($local) || $local === '0') {
@@ -126,6 +126,33 @@ if (!function_exists('blockify_get_field')) {
 
         if (!empty($global) || $global === '0') {
             return $global;
+        }
+
+        return $defaults[$option_name] ?? null;
+    }
+}
+
+if (!function_exists('blockify_get_field_global_first')) {
+    /**
+     * Отримує значення поля з пріоритетом: глобальне > локальне > дефолтне
+     *
+     * @param string $option_name Назва константи класу Options
+     * @param array  $defaults    Масив дефолтних значень (Options::DEFAULTS)
+     *
+     * @return mixed
+     */
+    function blockify_get_field_global_first(string $option_name, array $defaults)
+    {
+        $global = get_option($option_name);
+
+        if (!empty($global) || $global === '0') {
+            return $global;
+        }
+
+        $local = get_field($option_name);
+
+        if (!empty($local) || $local === '0') {
+            return $local;
         }
 
         return $defaults[$option_name] ?? null;


### PR DESCRIPTION
## Summary
- add `USE_GLOBAL_OPTIONS` and enable gradient checkbox globally for Hero block
- update helper to handle global priority
- allow using global settings in Hero block via new toggle

## Testing
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dc547630832cb134e28eda3d19cc