### PR TITLE
Enable global option toggle for Pro Steps block

### DIFF
--- a/blocks/pro-steps/fields.php
+++ b/blocks/pro-steps/fields.php
@@ -15,11 +15,30 @@ function register_pro_steps_acf_fields()
         'title' => 'Pro Steps Fields',
         'fields' => array(
             array(
+                'key' => create_acf_key(Options::USE_GLOBAL_OPTIONS),
+                'name' => Options::USE_GLOBAL_OPTIONS,
+                'label' => 'Use global options first',
+                'type' => 'true_false',
+                'ui' => 1,
+                'ui_on_text' => 'Yes',
+                'ui_off_text' => 'No',
+                'default_value' => 1,
+            ),
+            array(
                 'key' => create_acf_key(Options::NUMBER_COLOR),
                 'name' => Options::NUMBER_COLOR,
                 'label' => 'Number color',
                 'type' => 'color_picker',
                 'enable_opacity' => false,
+                'conditional_logic' => array(
+                    array(
+                        array(
+                            'field' => create_acf_key(Options::USE_GLOBAL_OPTIONS),
+                            'operator' => '!=',
+                            'value' => 1,
+                        ),
+                    ),
+                ),
             ),
             array(
                 'key' => create_acf_key(Options::BACKGROUND_COLOR),
@@ -27,6 +46,15 @@ function register_pro_steps_acf_fields()
                 'label' => 'Background color',
                 'type' => 'color_picker',
                 'enable_opacity' => true,
+                'conditional_logic' => array(
+                    array(
+                        array(
+                            'field' => create_acf_key(Options::USE_GLOBAL_OPTIONS),
+                            'operator' => '!=',
+                            'value' => 1,
+                        ),
+                    ),
+                ),
             ),
             array(
                 'key' => create_acf_key(Options::COLOR_FOR_GRADIENT),
@@ -34,6 +62,15 @@ function register_pro_steps_acf_fields()
                 'label' => 'Second background color for gradient',
                 'type' => 'color_picker',
                 'enable_opacity' => true,
+                'conditional_logic' => array(
+                    array(
+                        array(
+                            'field' => create_acf_key(Options::USE_GLOBAL_OPTIONS),
+                            'operator' => '!=',
+                            'value' => 1,
+                        ),
+                    ),
+                ),
             ),
             array(
                 'key' => create_acf_key(Options::LINE_COLOR),
@@ -41,6 +78,15 @@ function register_pro_steps_acf_fields()
                 'label' => 'Line color',
                 'type' => 'color_picker',
                 'enable_opacity' => false,
+                'conditional_logic' => array(
+                    array(
+                        array(
+                            'field' => create_acf_key(Options::USE_GLOBAL_OPTIONS),
+                            'operator' => '!=',
+                            'value' => 1,
+                        ),
+                    ),
+                ),
             ),
             array(
                 'key' => create_acf_key(Options::STEPS),

--- a/blocks/pro-steps/options.php
+++ b/blocks/pro-steps/options.php
@@ -12,12 +12,14 @@ final class Options {
     const BACKGROUND_COLOR    = 'pro_steps_background_color'; // the same
     const COLOR_FOR_GRADIENT  = 'blockify_pro_steps_color_for_gradient';
     const LINE_COLOR          = 'blockify_pro_steps_line_color';
+    const USE_GLOBAL_OPTIONS  = 'blockify_pro_steps_use_global_options';
 
     const DEFAULTS = [
         self::NUMBER_COLOR       => '#e6e6e6',
         self::BACKGROUND_COLOR   => '#efefef',
         self::COLOR_FOR_GRADIENT => 'rgba(0, 0, 0, 0)',
         self::LINE_COLOR         => '#cccccc',
+        self::USE_GLOBAL_OPTIONS => 0,
     ];
 
     const UPDATE_METHODS = [
@@ -35,6 +37,12 @@ final class Options {
     ];
 
     public static function getFieldWithDefaults($field_name) {
+        $use_global = get_field(self::USE_GLOBAL_OPTIONS);
+
+        if ($use_global) {
+            return blockify_get_field_global_first($field_name, self::DEFAULTS);
+        }
+
         return blockify_get_field($field_name, self::DEFAULTS);
     }
 }


### PR DESCRIPTION
## Summary
- add `USE_GLOBAL_OPTIONS` constant for Pro Steps block
- allow retrieving global options when enabled
- hide local settings when global options are used

## Testing
- `php -l blocks/pro-steps/options.php`
- `php -l blocks/pro-steps/fields.php`


------
https://chatgpt.com/codex/tasks/task_e_684ac8fabfec832cbf6ee7be1bacc7a7