### PR TITLE
Render meta name server-side

### DIFF
--- a/blocks/pro-steps/pro-steps.php
+++ b/blocks/pro-steps/pro-steps.php
@@ -15,6 +15,7 @@ $line_color          = Options::getFieldWithDefaults(Options::LINE_COLOR);
 $is_even_steps = count($steps) % 2 === 0;
 $anchor        = !empty($block['anchor']) ? 'id="' . esc_attr($block['anchor']) . '" ' : '';
 $class_name    = 'pro-block-steps' . (!empty($block['className']) ? ' ' . $block['className'] : '');
+$meta_heading  = blockify_get_prev_heading_for_anchor($block['anchor'] ?? '', $block['postId'] ?? 0);
 
 $css = <<<CSS
 :root {
@@ -25,7 +26,7 @@ $css = <<<CSS
 CSS;
 
 ?><style><?= blockify_minify_css($css) ?></style><section <?= $anchor; // phpcs:ignore ?> class="<?= esc_attr($class_name); ?>" itemscope itemtype="https://schema.org/HowTo">
-    <meta itemprop="name" content="" id="howto-block-name-meta">
+    <meta itemprop="name" content="<?= esc_attr($meta_heading); ?>" id="howto-block-name-meta">
     <ol>
         <?php foreach ($steps as $key => $step) :
             ++$key;
@@ -90,27 +91,3 @@ CSS;
         <?php endforeach; ?>
     </ol>
 </section>
-
-<script>
-    (function() {
-        const section = document.querySelector('.pro-block-steps[itemtype="https://schema.org/HowTo"]');
-
-        if (!section) {
-            return;
-        }
-
-        let node = section.previousElementSibling;
-        let found = '';
-
-        while(node && !found) {
-            if (node.matches && (node.matches('h2') || node.matches('h3') || node.matches('h4'))) {
-                found = node.textContent.trim();
-            }
-            node = node.previousElementSibling;
-        }
-
-        if (found) {
-            document.getElementById('howto-block-name-meta').setAttribute('content', found);
-        }
-    })();
-</script>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -210,8 +210,46 @@ if (!function_exists('blockify_minify_css')) {
      * @param string $css Вихідний CSS
      * @return string Мініфікований CSS
      */
-    function blockify_minify_css(string $css): string {
-        $css = preg_replace('/\s+/', ' ', $css);
-        return trim(str_replace(["\n", "\r", "\t"], '', $css));
+function blockify_minify_css(string $css): string {
+    $css = preg_replace('/\s+/', ' ', $css);
+    return trim(str_replace(["\n", "\r", "\t"], '', $css));
+}
+}
+
+if (!function_exists('blockify_get_prev_heading_for_anchor')) {
+    /**
+     * Повертає текст попереднього заголовка перед блоком із заданим якірним атрибутом.
+     *
+     * @param string $anchor  Значення атрибута id блоку.
+     * @param int    $post_id ID запису (необов'язковий).
+     *
+     * @return string Текст заголовка або порожній рядок.
+     */
+    function blockify_get_prev_heading_for_anchor(string $anchor, int $post_id = 0): string
+    {
+        if (empty($anchor)) {
+            return '';
+        }
+
+        $post_id = $post_id ?: get_the_ID();
+        $content = get_post_field('post_content', $post_id);
+
+        if (!$content) {
+            return '';
+        }
+
+        $position = strpos($content, 'id="' . $anchor . '"');
+
+        if ($position === false) {
+            return '';
+        }
+
+        $before = substr($content, 0, $position);
+
+        if (preg_match_all('/<h([234])[^>]*>(.*?)<\/h\1>/is', $before, $matches) && !empty($matches[2])) {
+            return trim(wp_strip_all_tags(end($matches[2])));
+        }
+
+        return '';
     }
 }


### PR DESCRIPTION
## Summary
- find heading preceding a block on the server side
- use this heading when rendering the meta name tag
- drop the JavaScript that previously set the meta value

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c472025e0832cab40a4b82c18f379