### PR TITLE
Fix heading detection for all page types

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -231,8 +231,30 @@ if (!function_exists('blockify_get_prev_heading_for_anchor')) {
             return '';
         }
 
-        $post_id = $post_id ?: get_the_ID();
-        $content = get_post_field('post_content', $post_id);
+        $content = '';
+
+        if ($post_id) {
+            $content = get_post_field('post_content', $post_id);
+        }
+
+        if (!$content) {
+            if (is_tax() || is_category() || is_tag()) {
+                $term = get_queried_object();
+                if ($term && !is_wp_error($term) && isset($term->description)) {
+                    $content = $term->description;
+                }
+            } elseif (is_home()) {
+                $posts_page = (int) get_option('page_for_posts');
+                if ($posts_page) {
+                    $content = get_post_field('post_content', $posts_page);
+                }
+            } else {
+                $queried_id = get_queried_object_id();
+                if ($queried_id) {
+                    $content = get_post_field('post_content', $queried_id);
+                }
+            }
+        }
 
         if (!$content) {
             return '';


### PR DESCRIPTION
## Summary
- handle taxonomy archives and posts page when searching for previous heading

## Testing
- `php` not installed; no tests run

------
https://chatgpt.com/codex/tasks/task_e_685c4f8f5278832ca002bc88e2c5122e